### PR TITLE
optimize ConcatenateTypeDefs

### DIFF
--- a/typedefs_test.go
+++ b/typedefs_test.go
@@ -16,7 +16,7 @@ func TestConcatenateTypeDefs(t *testing.T) {
 				name: String!
 				description: String
 			}
-			
+
 			extend type Query {
 				foo: Foo
 			}`,
@@ -24,12 +24,12 @@ func TestConcatenateTypeDefs(t *testing.T) {
 			interface Named {
 				name: String!
 			}
-			
+
 			type Bar implements Named {
 				name: String!
 				description: String
 			}
-			
+
 			extend type Query {
 				bar: Bar
 			}`,
@@ -74,7 +74,7 @@ func TestObjectIsTypeOf(t *testing.T) {
 				description: String
 			}
 			union Foo = A | B
-			
+
 			extend type Query {
 				foo: Foo
 			}`,
@@ -133,7 +133,7 @@ func TestUnionResolveType(t *testing.T) {
 				description: String
 			}
 			union Foo = A | B
-			
+
 			extend type Query {
 				foo: Foo
 			}`,


### PR DESCRIPTION
This was taking a ludicrous amount of time in Dagger's test suite (more generally on every session start, but Dagger's test suite is sort of a stress test for that).

Simply appending seems to work fine, even with duplicate type definitions. Considering the performance improvement, if we do end up running into any trouble it seems worth trying an alternative fix on top of this change rather than reverting it.

Performance comparison (GQL optimization = this change, ID refactor = https://github.com/dagger/dagger/pull/4973):

- no ID refactor, no GQL optimization
    - no profiling
        - DONE 359 tests in 211.938s
        - DONE 359 tests in 192.635s
    - profiling
        - DONE 359 tests in 203.365s
- yes ID refactor, no GQL optimization
    - DONE 359 tests, 1 skipped in 187.724s
- yes ID refactor, yes GQL optimization
    - profiling
        - DONE 359 tests, 1 skipped in 63.278s
        - DONE 359 tests, 1 skipped in 67.219s
        - DONE 359 tests, 1 skipped in 68.321s
        - DONE 359 tests, 1 skipped in 63.550s
    - no profiling
        - DONE 359 tests, 1 skipped in 60.048s
        - DONE 359 tests, 1 skipped in 59.450s
- no ID refactor, yes GQL optimization
    - DONE 359 tests in 97.016s
    - DONE 359 tests in 69.192s
    - DONE 359 tests in 88.365s
    - DONE 359 tests in 66.448s

Flamegraph before + after:

![image](https://user-images.githubusercontent.com/1880/232898234-6ec72cf2-9a82-4f7d-84a7-1dad3b50409a.png)

![image](https://user-images.githubusercontent.com/1880/232898270-e05450ff-b8a2-4209-8247-95f9c467afb2.png)